### PR TITLE
Add websocket port config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project provides a browser-based radar for Counter Strike 2. The web applic
 
 ### 1. Configuration
 1. Copy `.env.example` to `.env` and adjust the values if needed. The most important settings are the WebSocket `PORT` and the `AUTH_TOKEN` used for authentication.
-2. Run the program once so that `config.json` is generated in the project root. Edit `m_local_ip` in this file to match the local IP address of the machine running `usermode.exe`.
+2. Run the program once so that `config.json` is generated in the project root. Edit `m_local_ip` in this file to match the local IP address of the machine running `usermode.exe`. Adjust `m_ws_port` if you changed the WebSocket port.
 
 ### 2. Build and Run with Docker
 Make sure you have Docker and docker‑compose installed.
@@ -21,7 +21,7 @@ Make sure you have Docker and docker‑compose installed.
 docker-compose up --build
 ```
 
-The web interface will be available on port `5173` and the WebSocket server on the port defined in `.env` (default `22006`).
+The web interface will be available on port `5173` and the WebSocket server on the port defined in `.env`/`config.json` (default `22006`).
 
 ### 3. Using the Application
 1. Build the `usermode` project using Visual Studio and run `usermode.exe`.

--- a/usermode/src/dllmain.cpp
+++ b/usermode/src/dllmain.cpp
@@ -57,7 +57,7 @@ bool main()
         return {};
     }
 
-    const auto formatted_address = std::format("ws://{}:22006/cs2_webradar", ipv4_address);
+    const auto formatted_address = std::format("ws://{}:{}/cs2_webradar", ipv4_address, config_data.m_ws_port);
     static auto web_socket = easywsclient::WebSocket::from_url(formatted_address);
     if (!web_socket)
     {

--- a/usermode/src/utils/config.cpp
+++ b/usermode/src/utils/config.cpp
@@ -7,11 +7,12 @@ bool cfg::setup(config_data_t& config_data)
 	{
 		LOG_WARNING("cannot open file 'config.json'");
 
-		std::ofstream example_config("config.json");
-		example_config << std::format("{}", R"({
+                std::ofstream example_config("config.json");
+                example_config << std::format("{}", R"({
     "m_use_localhost": true,
     "m_local_ip": "192.168.x.x",
-    "m_public_ip": "x.x.x.x"
+    "m_public_ip": "x.x.x.x",
+    "m_ws_port": 22006
 })");
 
 		return {};

--- a/usermode/src/utils/config.hpp
+++ b/usermode/src/utils/config.hpp
@@ -2,11 +2,12 @@
 
 struct config_data_t
 {
-	bool m_use_localhost;
-	std::string m_local_ip;
-	std::string m_public_ip;
+        bool m_use_localhost;
+        std::string m_local_ip;
+        std::string m_public_ip;
+        int m_ws_port{ 22006 };
 
-	NLOHMANN_DEFINE_TYPE_INTRUSIVE(config_data_t, m_use_localhost, m_local_ip, m_public_ip)
+        NLOHMANN_DEFINE_TYPE_INTRUSIVE(config_data_t, m_use_localhost, m_local_ip, m_public_ip, m_ws_port)
 };
 
 namespace cfg


### PR DESCRIPTION
## Summary
- generate `m_ws_port` field in config file
- store websocket port in `config_data_t`
- use `m_ws_port` when building websocket URL
- document `m_ws_port` setting in README

## Testing
- `git commit -m "Add WebSocket port to config"`

------
https://chatgpt.com/codex/tasks/task_e_6882131c0ee88328b897c7827f42e873